### PR TITLE
Add FastAPI price API

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -1,0 +1,62 @@
+import csv
+import os
+from datetime import datetime, timezone
+from threading import RLock
+from typing import Optional
+
+
+class PriceCache:
+    def __init__(self, stock_data_manager):
+        self.mgr = stock_data_manager
+        self.lock = RLock()
+
+    def _to_iso(self, value) -> str:
+        if isinstance(value, datetime):
+            dt = value
+        else:
+            try:
+                dt = value.to_pydatetime()  # pandas Timestamp
+            except AttributeError:
+                dt = datetime.fromisoformat(str(value))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt.isoformat()
+
+    def get_latest(self, symbol: str) -> Optional[dict]:
+        sym = symbol.upper()
+        with self.lock:
+            for sd in getattr(self.mgr, "stock_data_list", []):
+                if getattr(sd, "ticker", "").upper() == sym:
+                    df = getattr(sd, "df", None)
+                    if df is not None and not df.empty:
+                        price = float(df["Close"].iloc[-1])
+                        as_of_val = df["Date"].iloc[-1]
+                        as_of = self._to_iso(as_of_val)
+                        return {
+                            "price": price,
+                            "as_of": as_of,
+                            "currency": "USD",
+                            "source": "memory",
+                        }
+            path = os.path.join("shared_data_csv", f"{sym}.csv")
+            if os.path.exists(path):
+                try:
+                    with open(path, newline="") as fh:
+                        reader = csv.DictReader(fh)
+                        last_row = None
+                        for last_row in reader:
+                            pass
+                    if last_row and "Close" in last_row and "Date" in last_row:
+                        price = float(last_row["Close"])
+                        as_of = self._to_iso(last_row["Date"])
+                        return {
+                            "price": price,
+                            "as_of": as_of,
+                            "currency": "USD",
+                            "source": "csv",
+                        }
+                except Exception:
+                    pass
+        return None

--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class PriceResponse(BaseModel):
+    symbol: str
+    price: Optional[float] = None
+    currency: Optional[str] = "USD"
+    as_of: Optional[str] = None  # ISO-8601
+    source: Optional[str] = None
+    status: str = Field(default="ok")
+    error_code: Optional[str] = None
+    message: Optional[str] = None
+
+
+class BatchRequest(BaseModel):
+    symbols: List[str]

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,88 @@
+import os
+from datetime import datetime, timezone
+from fastapi import FastAPI, HTTPException, Depends, Header
+from api.models import PriceResponse, BatchRequest
+from api.deps import PriceCache
+
+app = FastAPI(title="Omega Bull Data API", version="1.0.0")
+
+def auth_guard(authorization: str = Header(default=None)):
+    token = os.getenv("AUTH_TOKEN")
+    if token and authorization != f"Bearer {token}":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "uptime_seconds": app.state.uptime()}
+
+def _fetch(symbol: str, cache: PriceCache, threshold: int) -> PriceResponse:
+    sym = symbol.strip().upper()
+    if not sym:
+        raise HTTPException(
+            status_code=400,
+            detail={"error_code": "INVALID_REQUEST", "message": "symbol is required"},
+        )
+    data = cache.get_latest(sym)
+    if not data:
+        raise HTTPException(
+            status_code=404,
+            detail={"error_code": "SYMBOL_NOT_FOUND", "message": "symbol not found"},
+        )
+    as_of = datetime.fromisoformat(data["as_of"])
+    age = (datetime.now(timezone.utc) - as_of).total_seconds()
+    if age > threshold:
+        raise HTTPException(
+            status_code=503,
+            detail={"error_code": "STALE_DATA", "message": "price data is stale"},
+        )
+    return PriceResponse(
+        symbol=sym,
+        price=data["price"],
+        currency=data.get("currency", "USD"),
+        as_of=data["as_of"],
+        source=data.get("source"),
+    )
+
+@app.get("/v1/price", response_model=PriceResponse)
+def get_price(symbol: str, _: None = Depends(auth_guard)):
+    cache: PriceCache = app.state.cache
+    threshold = int(os.getenv("STALE_THRESHOLD_SECONDS", "120"))
+    try:
+        return _fetch(symbol, cache, threshold)
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=500,
+            detail={"error_code": "INTERNAL_ERROR", "message": "internal error"},
+        )
+
+@app.post("/v1/prices")
+def get_prices(body: BatchRequest, _: None = Depends(auth_guard)):
+    cache: PriceCache = app.state.cache
+    threshold = int(os.getenv("STALE_THRESHOLD_SECONDS", "120"))
+    results = []
+    for sym in body.symbols[:1000]:
+        try:
+            resp = _fetch(sym, cache, threshold)
+            results.append(resp.dict())
+        except HTTPException as e:
+            detail = e.detail if isinstance(e.detail, dict) else {"message": str(e.detail)}
+            results.append(
+                PriceResponse(
+                    symbol=sym.strip().upper(),
+                    status="error",
+                    error_code=detail.get("error_code"),
+                    message=detail.get("message"),
+                ).dict()
+            )
+        except Exception:
+            results.append(
+                PriceResponse(
+                    symbol=sym.strip().upper(),
+                    status="error",
+                    error_code="INTERNAL_ERROR",
+                    message="internal error",
+                ).dict()
+            )
+    return {"results": results}

--- a/main.py
+++ b/main.py
@@ -4,6 +4,10 @@ from stock.stock_data_manager import StockDataManager
 from shared_memory.shared_dict_manager import SharedDictManager, get_shared_dict
 
 if __name__ == "__main__":
+    print(
+        "WARNING: shared-dict interface is deprecated and will be removed after 2025-01-01",
+        flush=True,
+    )
     stock_data_manager = StockDataManager()
     lock = Lock()  # Create a Lock object
     manager = Manager()  # Create a Manager object

--- a/main_api.py
+++ b/main_api.py
@@ -1,0 +1,18 @@
+import os
+import time
+import uvicorn
+from stock.stock_data_manager import StockDataManager
+from api.server import app
+from api.deps import PriceCache
+
+if __name__ == "__main__":
+    mgr = StockDataManager()
+    mgr.start_downloader_agent()
+    app.state.cache = PriceCache(mgr)
+    app.state.start_time = time.time()
+    app.state.uptime = lambda: int(time.time() - app.state.start_time)
+    uvicorn.run(
+        app,
+        host=os.getenv("BIND", "0.0.0.0"),
+        port=int(os.getenv("PORT", "8080")),
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn==0.28.0
+pydantic==2.6.3

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,77 @@
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from api.server import app
+from api.deps import PriceCache
+
+
+class DummyStock:
+    def __init__(self, symbol: str, price: float):
+        now = datetime.now(timezone.utc)
+        self.ticker = symbol
+        self.df = pd.DataFrame([{"Date": now, "Close": price}])
+
+
+def create_client():
+    mgr = SimpleNamespace(stock_data_list=[
+        DummyStock("AAPL", 100.0),
+        DummyStock("MSFT", 200.0),
+    ])
+    app.state.cache = PriceCache(mgr)
+    app.state.start_time = time.time()
+    app.state.uptime = lambda: 0
+    return TestClient(app)
+
+
+@pytest.fixture
+def client():
+    return create_client()
+
+
+def test_health(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_get_price(client):
+    resp = client.get("/v1/price", params={"symbol": "AAPL"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["symbol"] == "AAPL"
+    assert body["price"] == 100.0
+
+
+def test_batch(client):
+    resp = client.post("/v1/prices", json={"symbols": ["AAPL", "MSFT", "BAD"]})
+    assert resp.status_code == 200
+    res = {r["symbol"]: r for r in resp.json()["results"]}
+    assert res["AAPL"]["status"] == "ok"
+    assert res["MSFT"]["status"] == "ok"
+    assert res["BAD"]["status"] == "error"
+    assert res["BAD"]["error_code"] == "SYMBOL_NOT_FOUND"
+
+
+def test_auth(monkeypatch):
+    monkeypatch.setenv("AUTH_TOKEN", "t")
+    client = create_client()
+    r = client.get("/v1/price", params={"symbol": "AAPL"})
+    assert r.status_code == 401
+    r2 = client.get(
+        "/v1/price",
+        params={"symbol": "AAPL"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert r2.status_code == 200
+    monkeypatch.delenv("AUTH_TOKEN")


### PR DESCRIPTION
## Summary
- introduce FastAPI server exposing `/health`, `/v1/price`, and `/v1/prices` endpoints with optional auth and staleness checks
- add PriceCache helper to fetch prices from memory or CSV
- add entrypoint `main_api.py` and deprecate shared-dict interface

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689f0c10f77c832a862e0468581bec33