### PR TITLE
Add NDJSON quote server with seqlock-protected shared memory

### DIFF
--- a/Arch/high-level-arch.md
+++ b/Arch/high-level-arch.md
@@ -1,0 +1,37 @@
+# High-Level Architecture
+
+## Overview
+
+The data manager maintains per-ticker history in shared memory and a small
+in-memory quote cache for the latest point-in-time price.  A global snapshot
+state tracks the last update epoch and timestamp using a seqlock style scheme.
+
+An NDJSON TCP server exposes discovery and point quote endpoints:
+
+- `list_tickers` — returns the set of tickers backed by shared memory
+- `get_quote` — retrieves the latest quote from the in-memory cache with stale
+  detection against the configured freshness window
+- `get_snapshot_epoch` — reports the current snapshot epoch and last update
+  timestamp for observability
+
+Clients interact with the server instead of reading the shared memory directly
+for point quotes, avoiding race conditions and heavy parsing.
+
+## Shared Memory Seqlock
+
+Shared memory entries include a header with `epoch` and `last_update_ms`.  The
+writer increments the epoch before and after updating an entry, leaving an even
+value when the data is stable.  Readers verify the epoch is unchanged and even
+before consuming a snapshot, ensuring they never observe torn writes.
+
+## Data Flow
+
+1. The data manager downloads new bars and updates shared memory entries.
+2. The in-memory quote cache is refreshed with the most recent bar for each
+   ticker.
+3. The snapshot state is updated with the current epoch and timestamp.
+4. The NDJSON server serves client requests using only the quote cache and
+   snapshot state for O(1) lookups.
+
+This separation keeps historical data in shared memory while enabling fast,
+thread-safe quote retrieval over the network.

--- a/shared_memory/shared_memory_manager.py
+++ b/shared_memory/shared_memory_manager.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import os
+import time
 from stock.stock_data_interface import StockDataInterface
 
 
@@ -13,6 +15,19 @@ class SharedMemoryManager(StockDataInterface):
         self.lock = lock
         self.stock_data_manager = stock_data_manager
         self.stock_data_manager.register_listener(self)
+
+        # In-memory cache for the most recent quote of each ticker. The server
+        # reads from this structure to serve `get_quote` requests in O(1)
+        # without touching the historical data stored in the shared dictionary.
+        self.quote_cache = {}
+
+        # Global snapshot state used by the server to report the last update
+        # epoch and timestamp. The epoch follows a seqlock style scheme where
+        # odd numbers indicate that a write is in progress.
+        self.snapshot_state = {"epoch": 0, "last_update_ms": 0}
+
+        self.writer_pid = os.getpid()
+
         self.stock_data_manager.start_downloader_agent()
 
     def on_download_started(self):
@@ -27,6 +42,11 @@ class SharedMemoryManager(StockDataInterface):
             print("Writing data to shared memory----------------------------------------------@@@@@@@")
             self.lock.acquire()
 
+            # Increment the global snapshot epoch to an odd number to signal
+            # that an update is in progress. Readers of the shared memory can
+            # detect this and retry until the epoch becomes even again.
+            self.snapshot_state["epoch"] += 1
+
             # Use the actual ticker symbol as the key in shared memory so clients
             # can access stock data by the expected ticker name instead of a
             # generated index like "stock_0".  This ensures the shared memory
@@ -34,7 +54,53 @@ class SharedMemoryManager(StockDataInterface):
             # expectations of consumers of this module.
             for stock_data in stock_data_list:
                 key = stock_data.ticker
-                self.shared_dict[key] = stock_data.to_serializable_dict()
+
+                # Retrieve existing entry or create a new one with a seqlock
+                # style header.  The header fields allow readers to determine
+                # whether they have observed a consistent snapshot.
+                entry = self.shared_dict.get(
+                    key,
+                    {
+                        "header": {
+                            "version": 1,
+                            "epoch": 0,
+                            "last_update_ms": 0,
+                            "writer_pid": self.writer_pid,
+                        },
+                        "data": None,
+                    },
+                )
+
+                # Mark the entry as being written by incrementing the epoch to
+                # an odd number before publishing any changes.
+                entry["header"]["epoch"] += 1
+                self.shared_dict[key] = entry
+
+                data_dict = stock_data.to_serializable_dict()
+
+                now_ms = int(time.time() * 1000)
+                entry["data"] = data_dict
+                entry["header"]["last_update_ms"] = now_ms
+                entry["header"]["epoch"] += 1
+                self.shared_dict[key] = entry
+
+                # Update in-memory quote cache for fast `get_quote` lookups.
+                try:
+                    if data_dict.get("df"):
+                        last = data_dict["df"][-1]
+                        ts_ms = int(
+                            time.mktime(time.strptime(last["Date"], "%Y-%m-%d"))
+                            * 1000
+                        )
+                        self.quote_cache[key] = {
+                            "price": last.get("Close"),
+                            "volume": last.get("Volume"),
+                            "currency": "USD",
+                            "ts_epoch_ms": ts_ms,
+                            "source": "shared_memory_manager",
+                        }
+                except Exception as cache_error:
+                    print(f"Error updating quote cache for {key}: {cache_error}")
 
                 try:
                     if stock_data.df is not None:
@@ -42,6 +108,11 @@ class SharedMemoryManager(StockDataInterface):
                         stock_data.df.to_csv(csv_path, index=False)
                 except Exception as csv_error:
                     print(f"Error while saving CSV for {stock_data.ticker}: {csv_error}")
+
+            # Finalize global snapshot epoch to an even value and record the
+            # last update timestamp.
+            self.snapshot_state["last_update_ms"] = int(time.time() * 1000)
+            self.snapshot_state["epoch"] += 1
 
             self.lock.release()
             print("finished writing data to shared memory")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,127 @@
+import asyncio
+import json
+from multiprocessing import Manager, Lock
+from pathlib import Path
+import sys
+
+import pytest
+
+# Ensure repository root on path for module imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared_memory.shared_memory_manager import SharedMemoryManager
+from quote_server import NDJSONServer
+
+
+class FakeStockData:
+    def __init__(self, ticker: str, price: float, volume: int, date: str = "2024-01-01"):
+        self.ticker = ticker
+        self.df = None  # avoiding pandas dependency
+        self._data = {
+            "ticker": ticker,
+            "start_date": date,
+            "cur_date": date,
+            "end_date": date,
+            "period": "1 D",
+            "df": [
+                {
+                    "Date": date,
+                    "Open": price,
+                    "High": price,
+                    "Low": price,
+                    "Close": price,
+                    "Volume": volume,
+                }
+            ],
+        }
+
+    def to_serializable_dict(self):
+        return self._data
+
+
+class FakeDataManager:
+    def __init__(self, stock_data_list):
+        self.stock_data_list = stock_data_list
+        self.scanner_listeners = []
+
+    def register_listener(self, listener):
+        self.scanner_listeners.append(listener)
+
+    def start_downloader_agent(self):
+        for l in self.scanner_listeners:
+            l.on_download_started()
+        for l in self.scanner_listeners:
+            l.on_download_finished()
+
+    def get_all_stock_data(self):
+        return self.stock_data_list
+
+
+async def send_request(port, obj):
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    writer.write(json.dumps(obj).encode() + b"\n")
+    await writer.drain()
+    resp_line = await reader.readline()
+    writer.close()
+    await writer.wait_closed()
+    return json.loads(resp_line.decode())
+
+
+def test_server_endpoints():
+    async def run_test():
+        mgr = Manager()
+        shared_dict = mgr.dict()
+        lock = Lock()
+
+        fake_data = [
+            FakeStockData("AAPL", 100.0, 10),
+            FakeStockData("MSFT", 200.0, 20),
+        ]
+        fdm = FakeDataManager(fake_data)
+        smm = SharedMemoryManager(shared_dict, lock, fdm)
+
+        server = NDJSONServer(smm.quote_cache, smm.snapshot_state)
+        srv = await server.start("127.0.0.1", 0)
+        port = srv.sockets[0].getsockname()[1]
+
+        # list_tickers
+        resp = await send_request(port, {"v": 1, "id": "1", "type": "list_tickers"})
+        assert set(resp["data"]) == {"AAPL", "MSFT"}
+
+        # get_quote success
+        resp = await send_request(port, {"v": 1, "id": "2", "type": "get_quote", "ticker": "AAPL"})
+        assert resp["data"]["price"] == 100.0
+        assert resp["data"]["ticker"] == "AAPL"
+
+        # get_quote not found
+        resp = await send_request(port, {"v": 1, "id": "3", "type": "get_quote", "ticker": "GOOG"})
+        assert resp["type"] == "error"
+        assert resp["error"]["code"] == "NOT_FOUND"
+
+        # malformed JSON
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(b"not json\n")
+        await writer.drain()
+        resp_line = await reader.readline()
+        writer.close()
+        await writer.wait_closed()
+        resp = json.loads(resp_line.decode())
+        assert resp["type"] == "error"
+        assert resp["error"]["code"] == "BAD_REQUEST"
+
+        # oversize line
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(b"{" + b"a" * 70000 + b"}\n")
+        await writer.drain()
+        resp_line = await reader.readline()
+        writer.close()
+        await writer.wait_closed()
+        resp = json.loads(resp_line.decode())
+        assert resp["type"] == "error"
+        assert resp["error"]["code"] == "BAD_REQUEST"
+
+        srv.close()
+        await srv.wait_closed()
+        mgr.shutdown()
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- implement NDJSON TCP server exposing `list_tickers`, `get_quote`, and `get_snapshot_epoch`
- add seqlock headers and quote cache to shared memory manager
- document high-level architecture for the quote server and seqlock flow
- integration test covering happy paths and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f14518f64832aaf9d127d203bc348